### PR TITLE
feat: extract sidebar component

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,8 @@ Task: Split index.css into modular styles
 Commit: <hash>
 Files: index.css, src/main.tsx, src/styles/global.css, src/styles/sidebar.css, src/styles/chat.css, src/styles/hub.css, src/styles/settings.css, src/styles/modal.css
 Notes: Extracted page-specific rules to dedicated CSS files and updated imports.
+
+Task: Extract sidebar component
+Commit: 6626bc9
+Files: src/components/Sidebar.tsx, src/pages/LegacyShell.tsx, README.md
+Notes: Moved sidebar markup into Sidebar component and updated LegacyShell.

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+export default function Sidebar() {
+  return (
+    <aside id="container-sidebar" className="container-sidebar">
+      <div className="sidebar-header">
+        <h2 id="sidebar-container-title">Container</h2>
+      </div>
+      <nav className="sidebar-nav">
+        <button id="new-chat-btn" className="sidebar-link new-chat-btn">
+          <svg xmlns="http://www.w3.org/2000/svg" width={20} height={20} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><line x1={12} y1={5} x2={12} y2={19} /><line x1={5} y1={12} x2={19} y2={12} /></svg>
+          <span>New Chat</span>
+        </button>
+        <ul id="sidebar-main-nav">
+          <li><a id="sidebar-assistant-link" className="sidebar-link active"><svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" /></svg><span>Assistant</span></a></li>
+          <li><a id="sidebar-knowledge-link" className="sidebar-link"><svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" /><path d="M6.5 2H20v15H6.5A2.5 2.5 0 0 1 4 14.5v-10A2.5 2.5 0 0 1 6.5 2z" /></svg><span>Knowledge</span></a></li>
+        </ul>
+        <div id="sidebar-integrations-section" className="sidebar-section" />
+        <div id="sidebar-apps-section" className="sidebar-section" />
+        <div id="sidebar-history-section" className="sidebar-section">
+          <h3 className="sidebar-section-title">History</h3>
+          <ul id="sidebar-history-list" />
+        </div>
+      </nav>
+    </aside>
+  );
+}
+

--- a/src/pages/LegacyShell.tsx
+++ b/src/pages/LegacyShell.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { GoogleGenAI, Chat, Part, Type, GenerateContentResponse } from '@google/genai';
+import Sidebar from '../components/Sidebar';
 
 export default function LegacyShell() {
   useEffect(() => {
@@ -2786,27 +2787,7 @@ Available function icons: ${FUNCTION_ICONS.join('\n')}`;
     </div>
     {/* Default Container Page View */}
     <div id="container-page" className="page-view hidden">
-      <aside id="container-sidebar" className="container-sidebar">
-        <div className="sidebar-header">
-          <h2 id="sidebar-container-title">Container</h2>
-        </div>
-        <nav className="sidebar-nav">
-          <button id="new-chat-btn" className="sidebar-link new-chat-btn">
-            <svg xmlns="http://www.w3.org/2000/svg" width={20} height={20} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><line x1={12} y1={5} x2={12} y2={19} /><line x1={5} y1={12} x2={19} y2={12} /></svg>
-            <span>New Chat</span>
-          </button>
-          <ul id="sidebar-main-nav">
-            <li><a id="sidebar-assistant-link" className="sidebar-link active"><svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" /></svg><span>Assistant</span></a></li>
-            <li><a id="sidebar-knowledge-link" className="sidebar-link"><svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" /><path d="M6.5 2H20v15H6.5A2.5 2.5 0 0 1 4 14.5v-10A2.5 2.5 0 0 1 6.5 2z" /></svg><span>Knowledge</span></a></li>
-          </ul>
-          <div id="sidebar-integrations-section" className="sidebar-section" />
-          <div id="sidebar-apps-section" className="sidebar-section" />
-          <div id="sidebar-history-section" className="sidebar-section">
-            <h3 className="sidebar-section-title">History</h3>
-            <ul id="sidebar-history-list" />
-          </div>
-        </nav>
-      </aside>
+      <Sidebar />
       <div className="container-page-container">
         <header className="app-header">
           <div className="header-left">


### PR DESCRIPTION
## Summary
- extract container sidebar into reusable `Sidebar` component
- replace inline sidebar markup in `LegacyShell` with component usage
- log new component in Task Log

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a2005e46c48327a90b7a8255face26