### PR TITLE
feat: add error boundary component

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,7 @@ Task: Configure ESLint
 Commit: <hash>
 Files: .eslintrc.json, package.json, package-lock.json, README.md
 Notes: Added ESLint with React, a11y, and TypeScript rules and lint script.
+Task: Add error boundary component
+Commit: <hash>
+Files: src/components/ErrorBoundary.tsx, src/App.tsx, README.md
+Notes: Added class-based ErrorBoundary and wrapped LegacyShell with it.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import LegacyShell from './pages/LegacyShell';
+import ErrorBoundary from './components/ErrorBoundary';
 
 export default function App() {
-  return <LegacyShell />;
+  return (
+    <ErrorBoundary>
+      <LegacyShell />
+    </ErrorBoundary>
+  );
 }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,37 @@
+import React, { ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+  }
+
+  declare props: ErrorBoundaryProps;
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    // You might integrate with logging infrastructure here
+    console.error('ErrorBoundary caught an error', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <p>Something went wrong.</p>;
+    }
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary
- add class-based ErrorBoundary component
- wrap LegacyShell with ErrorBoundary

## Testing
- `npm run lint` (fails: anchor-is-valid, label-has-associated-control, etc.)
- `npm run typecheck`
- `npm run test:visual` (fails: Playwright browsers missing)


------
https://chatgpt.com/codex/tasks/task_e_68a20772a33083279352bd165fe443d2