### PR TITLE
fix: correct empty src attributes in LegacyShell.tsx

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
   "rules": {
     "jsx-a11y/aria-props": "error",
     "react/prop-types": "off",
+    "react/no-unknown-property": "error",
     "jsx-a11y/label-has-associated-control": "off",
     "jsx-a11y/img-redundant-alt": "off",
     "jsx-a11y/anchor-is-valid": "off",

--- a/README.md
+++ b/README.md
@@ -143,3 +143,7 @@ Task: Replace favicon.ico with SVG
 Commit: 831cf77
 Files: public/favicon.svg, index.html
 Notes: Used SVG favicon due to .ico restrictions.
+Task: Fix empty src attributes in LegacyShell.tsx
+Commit: 6904f2b
+Files: src/pages/LegacyShell.tsx, .eslintrc.json, README.md
+Notes: Replaced empty image src values with null and tightened ESLint rules.

--- a/src/pages/LegacyShell.tsx
+++ b/src/pages/LegacyShell.tsx
@@ -2339,7 +2339,7 @@ export default function LegacyShell() {
                 <div className="form-group">
                   <label htmlFor="edit-custom-icon-upload" className="form-label">Upload Custom Icon</label>
                   <div className="custom-icon-uploader">
-                    <img id="edit-custom-icon-preview" src="" alt="Custom icon preview" className="custom-icon-preview hidden" />
+                      <img id="edit-custom-icon-preview" src={null} alt="Custom icon preview" className="custom-icon-preview hidden" />
                     <button type="button" id="edit-custom-icon-btn" className="modal-btn modal-btn-secondary">Choose Image...</button>
                     <input type="file" id="edit-custom-icon-upload" className="hidden" accept="image/png, image/jpeg, image/webp, image/svg+xml" />
                   </div>
@@ -2352,7 +2352,7 @@ export default function LegacyShell() {
                   <label className="form-label">Card Background Image</label>
                   <div className="card-image-selector">
                     <div id="card-image-options-list" className="icon-selector-grid" />
-                    <img id="edit-card-image-preview" src="" alt="Card image preview" className="card-image-preview hidden" />
+                      <img id="edit-card-image-preview" src={null} alt="Card image preview" className="card-image-preview hidden" />
                     <button type="button" id="edit-card-image-btn" className="modal-btn modal-btn-secondary">Upload Custom Image...</button>
                     <input type="file" id="edit-card-image-upload" className="hidden" accept="image/png, image/jpeg, image/webp" />
                   </div>
@@ -2706,7 +2706,7 @@ export default function LegacyShell() {
                 <div className="form-group">
                   <label htmlFor="add-custom-icon-upload" className="form-label">Or Upload Custom Icon</label>
                   <div className="custom-icon-uploader">
-                    <img id="add-custom-icon-preview" src="" alt="Custom icon preview" className="custom-icon-preview hidden" />
+                      <img id="add-custom-icon-preview" src={null} alt="Custom icon preview" className="custom-icon-preview hidden" />
                     <button type="button" id="add-custom-icon-btn" className="modal-btn modal-btn-secondary">Choose Image...</button>
                     <input type="file" id="add-custom-icon-upload" className="hidden" accept="image/png, image/jpeg, image/webp, image/svg+xml" />
                   </div>


### PR DESCRIPTION
## Summary
- replace empty image `src` values with `null` in LegacyShell
- enforce `react/no-unknown-property` via ESLint
- document task in README

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- `npm start` (terminated)

------
https://chatgpt.com/codex/tasks/task_e_68a213b76f088327a710b966b48368a6