### PR TITLE
feat: add stubbed SSO login handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,8 @@ Task: Add routing and stub pages
 Commit: 82ada7e, 8537d28
 Files: package.json, src/App.tsx, src/components/Sidebar.tsx, src/pages/Login.tsx, src/pages/Hub.tsx, src/pages/SettingsHub.tsx, src/pages/GlobalSettings.tsx, src/pages/Workspace.tsx, src/pages/Knowledge.tsx, src/pages/LegacyShell.tsx
 Notes: Introduced react-router-dom routing and migrated legacy sections into dedicated pages with debugging logs.
+
+Task: Add stubbed SSO login handlers
+Commit: f60e4fb, c57df81
+Files: src/pages/Login.tsx, src/types/api.ts, src/lib/msal.ts, README.md
+Notes: Hooked sign-in buttons to mock auth functions and navigation to maintain behavior.

--- a/src/lib/msal.ts
+++ b/src/lib/msal.ts
@@ -1,0 +1,9 @@
+import { UserProfile } from '../types/api';
+
+export const signInWithGoogle = async (): Promise<UserProfile> => {
+  return { name: 'Mock User', email: 'user@example.com' };
+};
+
+export const signInWithMicrosoft = async (): Promise<UserProfile> => {
+  return { name: 'Mock User', email: 'user@example.com' };
+};

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,9 +1,25 @@
 import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { signInWithGoogle, signInWithMicrosoft } from '../lib/msal';
 
 export default function Login() {
+  const navigate = useNavigate();
   useEffect(() => {
     console.log('Route loaded: /login');
   }, []);
+
+  const handleGoogleLogin = async () => {
+    console.log('Button clicked: Sign in with Google');
+    await signInWithGoogle();
+    navigate('/hub');
+  };
+
+  const handleMicrosoftLogin = async () => {
+    console.log('Button clicked: Sign in with Microsoft');
+    await signInWithMicrosoft();
+    navigate('/hub');
+  };
+
   return (
     <div id="login-page" className="page-view">
       <div className="login-container">
@@ -16,11 +32,11 @@ export default function Login() {
         <h1 id="login-title-text" className="login-title">The Future of Tech</h1>
         <p id="login-subtitle-text" className="login-subtitle">Sign in to continue</p>
         <div className="sso-buttons">
-          <button id="google-login" className="sso-btn google-btn" aria-label="Sign in with Google" onClick={() => console.log('Button clicked: Sign in with Google')}>
+          <button id="google-login" className="sso-btn google-btn" aria-label="Sign in with Google" onClick={handleGoogleLogin}>
             <svg viewBox="0 0 48 48" width={24} height={24}><path fill="#FFC107" d="M43.611,20.083H42V20H24v8h11.303c-1.649,4.657-6.08,8-11.303,8c-6.627,0-12-5.373-12-12c0-6.627,5.373-12,12-12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C12.955,4,4,12.955,4,24c0,11.045,8.955,20,20,20c11.045,0,20-8.955,20-20C44,22.659,43.862,21.35,43.611,20.083z" /><path fill="#FF3D00" d="M6.306,14.691l6.571,4.819C14.655,15.108,18.961,12,24,12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C16.318,4,9.656,8.337,6.306,14.691z" /><path fill="#4CAF50" d="M24,44c5.166,0,9.86-1.977,13.409-5.192l-6.19-5.238C29.211,35.091,26.715,36,24,36c-5.222,0-9.619-3.317-11.283-7.946l-6.522,5.025C9.505,39.556,16.227,44,24,44z" /><path fill="#1976D2" d="M43.611,20.083H42V20H24v8h11.303c-0.792,2.237-2.231,4.166-4.087,5.571l6.19,5.238C43.021,36.251,44,30.495,44,24C44,22.659,43.862,21.35,43.611,20.083z" /></svg>
             <span>Sign in with Google</span>
           </button>
-          <button id="microsoft-login" className="sso-btn microsoft-btn" aria-label="Sign in with Microsoft" onClick={() => console.log('Button clicked: Sign in with Microsoft')}>
+          <button id="microsoft-login" className="sso-btn microsoft-btn" aria-label="Sign in with Microsoft" onClick={handleMicrosoftLogin}>
             <svg viewBox="0 0 21 21" width={21} height={21} fill="currentColor"><path d="M1 1h9v9H1z" fill="#f25022" /><path d="M11 1h9v9h-9z" fill="#7fba00" /><path d="M1 11h9v9H1z" fill="#00a4ef" /><path d="M11 11h9v9h-9z" fill="#ffb900" /></svg>
             <span>Sign in with Microsoft</span>
           </button>

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,3 +1,8 @@
 export interface LLMResponse {
   response: string;
 }
+
+export interface UserProfile {
+  name: string;
+  email: string;
+}


### PR DESCRIPTION
## Summary
- wire login buttons to mock auth functions and navigate to hub
- add msal stub and user profile type
- document stubbed login in task log

## Testing
- `npm run typecheck`
- `npm run test:visual` *(fails: browserType.launch: Executable doesn't exist; requires `npx playwright install` but download failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a2326cda148327a59a9d3e473493cb