### PR TITLE
fix: add navigation across portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,3 +156,7 @@ Task: Add stubbed SSO login handlers
 Commit: f60e4fb, c57df81
 Files: src/pages/Login.tsx, src/types/api.ts, src/lib/msal.ts, README.md
 Notes: Hooked sign-in buttons to mock auth functions and navigation to maintain behavior.
+Task: Fix portal navigation buttons
+Commit: cde6ac4, d8ec486
+Files: src/App.tsx, src/pages/Hub.tsx, src/pages/SettingsHub.tsx, src/pages/GlobalSettings.tsx, src/pages/Workspace.tsx, src/pages/Knowledge.tsx, src/pages/ContainerManagement.tsx
+Notes: Wired settings, back, and logout buttons to React Router routes and added container management stub.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import SettingsHub from './pages/SettingsHub';
 import GlobalSettings from './pages/GlobalSettings';
 import Workspace from './pages/Workspace';
 import Knowledge from './pages/Knowledge';
+import ContainerManagement from './pages/ContainerManagement';
 
 export default function App() {
   return (
@@ -17,6 +18,7 @@ export default function App() {
           <Route path="/login" element={<Login />} />
           <Route path="/hub" element={<Hub />} />
           <Route path="/settings" element={<SettingsHub />} />
+          <Route path="/settings/containers" element={<ContainerManagement />} />
           <Route path="/settings/global" element={<GlobalSettings />} />
           <Route path="/workspace/:id" element={<Workspace />} />
           <Route path="/workspace/:id/knowledge" element={<Knowledge />} />

--- a/src/pages/ContainerManagement.tsx
+++ b/src/pages/ContainerManagement.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function ContainerManagement() {
+  const navigate = useNavigate();
+  useEffect(() => {
+    console.log('Route loaded: /settings/containers');
+  }, []);
+  return (
+    <div id="container-management-page" className="page-view">
+      <header className="app-header">
+        <div className="header-left">
+          <button
+            className="back-to-settings-btn header-icon-btn"
+            aria-label="Back to Settings"
+            onClick={() => navigate('/settings')}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><line x1={19} y1={12} x2={5} y2={12} /><polyline points="12 19 5 12 12 5" /></svg>
+          </button>
+          <span id="container-management-title" className="header-title">Container Management</span>
+        </div>
+        <div className="header-right">
+          <button
+            className="back-to-hub-btn header-icon-btn"
+            aria-label="Go to Hub"
+            onClick={() => navigate('/hub')}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" /><polyline points="9 22 9 12 15 12 15 22" /></svg>
+          </button>
+        </div>
+      </header>
+      <div className="settings-container">
+        <h1 className="settings-title">Container Management</h1>
+        <div id="container-management-grid" className="container-management-grid" />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/GlobalSettings.tsx
+++ b/src/pages/GlobalSettings.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 export default function GlobalSettings() {
+  const navigate = useNavigate();
   useEffect(() => {
     console.log('Route loaded: /settings/global');
   }, []);
@@ -8,13 +10,22 @@ export default function GlobalSettings() {
     <div id="global-settings-page" className="page-view">
       <header className="app-header">
         <div className="header-left">
-          <button id="back-to-settings-hub-btn-2" className="header-icon-btn" aria-label="Back to Settings" onClick={() => console.log("Button clicked: Back to Settings")}>
+          <button
+            id="back-to-settings-hub-btn-2"
+            className="header-icon-btn"
+            aria-label="Back to Settings"
+            onClick={() => navigate('/settings')}
+          >
             <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><line x1={19} y1={12} x2={5} y2={12} /><polyline points="12 19 5 12 12 5" /></svg>
           </button>
           <span id="global-settings-title" className="header-title">Global Settings</span>
         </div>
         <div className="header-right">
-          <button className="back-to-hub-btn header-icon-btn" aria-label="Go to Hub" onClick={() => console.log("Button clicked: Go to Hub")}>
+          <button
+            className="back-to-hub-btn header-icon-btn"
+            aria-label="Go to Hub"
+            onClick={() => navigate('/hub')}
+          >
             <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" /><polyline points="9 22 9 12 15 12 15 22" /></svg>
           </button>
         </div>

--- a/src/pages/Hub.tsx
+++ b/src/pages/Hub.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 export default function Hub() {
+  const navigate = useNavigate();
   useEffect(() => {
     console.log('Route loaded: /hub');
   }, []);
@@ -17,7 +19,12 @@ export default function Hub() {
           <span id="hub-header-title" className="header-title">The Hub</span>
         </div>
         <div className="header-right">
-          <button id="settings-btn" className="header-icon-btn" aria-label="Open Settings" onClick={() => console.log('Button clicked: Open Settings')}>
+          <button
+            id="settings-btn"
+            className="header-icon-btn"
+            aria-label="Open Settings"
+            onClick={() => navigate('/settings')}
+          >
             <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><circle cx={12} cy={12} r={3} /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" /></svg>
           </button>
           <div className="user-profile-menu">
@@ -33,7 +40,15 @@ export default function Hub() {
                 <strong>Alex Thorne</strong>
                 <span>alex.thorne@example.com</span>
               </div>
-              <a href="#" className="dropdown-link" data-action="logout">
+              <a
+                href="#"
+                className="dropdown-link"
+                data-action="logout"
+                onClick={(e) => {
+                  e.preventDefault();
+                  navigate('/login');
+                }}
+              >
                 <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" /><polyline points="16 17 21 12 16 7" /><line x1={21} y1={12} x2={9} y2={12} /></svg>
                 <span>Logout</span>
               </a>

--- a/src/pages/Knowledge.tsx
+++ b/src/pages/Knowledge.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 
 export default function Knowledge() {
+  const navigate = useNavigate();
+  const { id } = useParams();
   useEffect(() => {
     console.log('Route loaded: /workspace/:id/knowledge');
   }, []);
@@ -8,7 +11,12 @@ export default function Knowledge() {
     <div id="knowledge-page" className="page-view">
       <header className="app-header">
         <div className="header-left">
-          <button id="back-to-assistant-btn" className="header-icon-btn" aria-label="Back to Assistant" onClick={() => console.log('Button clicked: Back to Assistant')}>
+          <button
+            id="back-to-assistant-btn"
+            className="header-icon-btn"
+            aria-label="Back to Assistant"
+            onClick={() => navigate(`/workspace/${id}`)}
+          >
             <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><line x1={19} y1={12} x2={5} y2={12} /><polyline points="12 19 5 12 12 5" /></svg>
           </button>
           <span id="knowledge-page-title" className="header-title">Knowledge Base</span>

--- a/src/pages/SettingsHub.tsx
+++ b/src/pages/SettingsHub.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 export default function SettingsHub() {
+  const navigate = useNavigate();
   useEffect(() => {
     console.log('Route loaded: /settings');
   }, []);
@@ -8,13 +10,21 @@ export default function SettingsHub() {
     <div id="settings-hub-page" className="page-view">
       <header className="app-header">
         <div className="header-left">
-          <button className="back-to-hub-btn header-icon-btn" aria-label="Back to Hub" onClick={() => console.log('Button clicked: Back to Hub')}>
+          <button
+            className="back-to-hub-btn header-icon-btn"
+            aria-label="Back to Hub"
+            onClick={() => navigate('/hub')}
+          >
             <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><line x1={19} y1={12} x2={5} y2={12} /><polyline points="12 19 5 12 12 5" /></svg>
           </button>
           <span id="settings-hub-title" className="header-title">Settings</span>
         </div>
         <div className="header-right">
-          <button className="back-to-hub-btn header-icon-btn" aria-label="Go to Hub" onClick={() => console.log('Button clicked: Go to Hub')}>
+          <button
+            className="back-to-hub-btn header-icon-btn"
+            aria-label="Go to Hub"
+            onClick={() => navigate('/hub')}
+          >
             <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" /><polyline points="9 22 9 12 15 12 15 22" /></svg>
           </button>
         </div>
@@ -22,14 +32,28 @@ export default function SettingsHub() {
       <div className="settings-container">
         <h1 className="settings-title">Settings</h1>
         <div className="settings-hub-grid">
-          <div id="container-management-card" className="settings-hub-card" role="button" tabIndex={0} onClick={() => console.log('Card clicked: Container Management')} onKeyDown={(e) => e.key === 'Enter' && console.log('Card clicked: Container Management')}>
+          <div
+            id="container-management-card"
+            className="settings-hub-card"
+            role="button"
+            tabIndex={0}
+            onClick={() => navigate('/settings/containers')}
+            onKeyDown={(e) => e.key === 'Enter' && navigate('/settings/containers')}
+          >
             <div className="settings-hub-card-icon">
               <svg xmlns="http://www.w3.org/2000/svg" width={48} height={48} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><rect x={3} y={3} width={7} height={7} /><rect x={14} y={3} width={7} height={7} /><rect x={14} y={14} width={7} height={7} /><rect x={3} y={14} width={7} height={7} /></svg>
             </div>
             <h2 className="settings-hub-card-title">Container Management</h2>
             <p className="settings-hub-card-desc">Create, edit, and manage all your containers and their specific settings.</p>
           </div>
-          <div id="global-settings-card" className="settings-hub-card" role="button" tabIndex={0} onClick={() => console.log('Card clicked: Global Settings')} onKeyDown={(e) => e.key === 'Enter' && console.log('Card clicked: Global Settings')}>
+          <div
+            id="global-settings-card"
+            className="settings-hub-card"
+            role="button"
+            tabIndex={0}
+            onClick={() => navigate('/settings/global')}
+            onKeyDown={(e) => e.key === 'Enter' && navigate('/settings/global')}
+          >
             <div className="settings-hub-card-icon">
               <svg xmlns="http://www.w3.org/2000/svg" width={48} height={48} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><circle cx={12} cy={12} r={3} /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" /></svg>
             </div>

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Sidebar from '../components/Sidebar';
 
 export default function Workspace() {
+  const navigate = useNavigate();
   useEffect(() => {
     console.log('Route loaded: /workspace/:id');
   }, []);
@@ -15,7 +17,11 @@ export default function Workspace() {
             <button id="sidebar-toggle-btn" className="header-icon-btn" aria-label="Toggle sidebar" onClick={() => console.log("Button clicked: Toggle sidebar")}>
               <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><line x1={3} y1={12} x2={21} y2={12} /><line x1={3} y1={6} x2={21} y2={6} /><line x1={3} y1={18} x2={21} y2={18} /></svg>
             </button>
-            <button className="back-to-hub-btn header-icon-btn" aria-label="Back to Hub" onClick={() => console.log("Button clicked: Back to Hub")}>
+            <button
+              className="back-to-hub-btn header-icon-btn"
+              aria-label="Back to Hub"
+              onClick={() => navigate('/hub')}
+            >
               <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><line x1={19} y1={12} x2={5} y2={12} /><polyline points="12 19 5 12 12 5" /></svg>
             </button>
             <span id="container-page-title" className="header-title">Container Assistant</span>


### PR DESCRIPTION
## Summary
- wire settings and navigation buttons across hub, settings, global settings, workspace, and knowledge pages
- stub container management page and route
- document portal navigation work in README task log

## Testing
- `npm run typecheck`
- `npm run test:visual` *(fails: browserType.launch: Executable doesn't exist; run `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68a234e4b4088327a2f7f72244441020