### PR TITLE
fix: activate stubbed UI buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,7 @@ Task: Fix portal navigation buttons
 Commit: cde6ac4, d8ec486
 Files: src/App.tsx, src/pages/Hub.tsx, src/pages/SettingsHub.tsx, src/pages/GlobalSettings.tsx, src/pages/Workspace.tsx, src/pages/Knowledge.tsx, src/pages/ContainerManagement.tsx
 Notes: Wired settings, back, and logout buttons to React Router routes and added container management stub.
+Task: Activate stubbed UI buttons
+Commit: 3919afa
+Files: src/pages/Hub.tsx, src/pages/ContainerManagement.tsx, src/pages/GlobalSettings.tsx
+Notes: Enabled profile dropdown, add container button, settings tabs and form controls.

--- a/src/pages/ContainerManagement.tsx
+++ b/src/pages/ContainerManagement.tsx
@@ -31,6 +31,13 @@ export default function ContainerManagement() {
       </header>
       <div className="settings-container">
         <h1 className="settings-title">Container Management</h1>
+        <button
+          id="add-container-btn"
+          className="modal-btn modal-btn-primary"
+          onClick={() => console.log('Add Container')}
+        >
+          Add Container
+        </button>
         <div id="container-management-grid" className="container-management-grid" />
       </div>
     </div>

--- a/src/pages/GlobalSettings.tsx
+++ b/src/pages/GlobalSettings.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 export default function GlobalSettings() {
   const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState('branding');
   useEffect(() => {
     console.log('Route loaded: /settings/global');
   }, []);
@@ -33,15 +34,45 @@ export default function GlobalSettings() {
       <div className="settings-container">
         <h1 className="settings-title">Global Settings</h1>
         <nav id="global-settings-tabs" className="settings-tabs">
-          <button className="tab-link active" data-tab="branding">Branding &amp; Appearance</button>
-          <button className="tab-link" data-tab="models">Model Management</button>
-          <button className="tab-link" data-tab="auth">Authentication</button>
-          <button className="tab-link" data-tab="privacy">Privacy &amp; Cookies</button>
-          <button className="tab-link" data-tab="integrations">Integrations</button>
+          <button
+            className={`tab-link ${activeTab === 'branding' ? 'active' : ''}`}
+            data-tab="branding"
+            onClick={() => setActiveTab('branding')}
+          >
+            Branding &amp; Appearance
+          </button>
+          <button
+            className={`tab-link ${activeTab === 'models' ? 'active' : ''}`}
+            data-tab="models"
+            onClick={() => setActiveTab('models')}
+          >
+            Model Management
+          </button>
+          <button
+            className={`tab-link ${activeTab === 'auth' ? 'active' : ''}`}
+            data-tab="auth"
+            onClick={() => setActiveTab('auth')}
+          >
+            Authentication
+          </button>
+          <button
+            className={`tab-link ${activeTab === 'privacy' ? 'active' : ''}`}
+            data-tab="privacy"
+            onClick={() => setActiveTab('privacy')}
+          >
+            Privacy &amp; Cookies
+          </button>
+          <button
+            className={`tab-link ${activeTab === 'integrations' ? 'active' : ''}`}
+            data-tab="integrations"
+            onClick={() => setActiveTab('integrations')}
+          >
+            Integrations
+          </button>
         </nav>
         <form id="global-settings-form">
           <div id="global-settings-panels" className="settings-panels">
-            <div id="tab-panel-branding" className="tab-panel active">
+            <div id="tab-panel-branding" className={`tab-panel ${activeTab === 'branding' ? 'active' : ''}`}>
               <div className="settings-section">
                 <div className="appearance-layout">
                   <div className="appearance-controls">
@@ -93,7 +124,7 @@ export default function GlobalSettings() {
                 </div>
               </div>
             </div>
-            <div id="tab-panel-models" className="tab-panel">
+            <div id="tab-panel-models" className={`tab-panel ${activeTab === 'models' ? 'active' : ''}`}>
               <div className="settings-section">
                 <h2 className="settings-section-title">AI Model Management</h2>
                 <p className="settings-section-description">Add, edit, or remove the AI models available across the application. The model ID should match the API identifier (e.g., 'gemini-2.5-flash').</p>
@@ -106,7 +137,7 @@ export default function GlobalSettings() {
                 <button type="submit" className="modal-btn modal-btn-primary">Add Model</button>
               </div>
             </div>
-            <div id="tab-panel-auth" className="tab-panel">
+            <div id="tab-panel-auth" className={`tab-panel ${activeTab === 'auth' ? 'active' : ''}`}>
               <div className="settings-section">
                 <h2 className="settings-section-title">Authentication (OAuth)</h2>
                 <p className="settings-section-description">Enable or disable third-party login providers and configure their credentials.</p>
@@ -142,7 +173,7 @@ export default function GlobalSettings() {
                 </div>
               </div>
             </div>
-            <div id="tab-panel-privacy" className="tab-panel">
+            <div id="tab-panel-privacy" className={`tab-panel ${activeTab === 'privacy' ? 'active' : ''}`}>
               <div className="settings-section">
                 <h2 className="settings-section-title">Privacy &amp; Cookies</h2>
                 <p className="settings-section-description">Manage privacy settings for your users.</p>
@@ -156,7 +187,7 @@ export default function GlobalSettings() {
                 </div>
               </div>
             </div>
-            <div id="tab-panel-integrations" className="tab-panel">
+            <div id="tab-panel-integrations" className={`tab-panel ${activeTab === 'integrations' ? 'active' : ''}`}>
               <div className="settings-section">
                 <h2 className="settings-section-title">Integrations</h2>
                 <p className="settings-section-description">Globally enable or disable integrations. They can be activated per-container in the container's settings.</p>
@@ -165,10 +196,25 @@ export default function GlobalSettings() {
                 </div>
               </div>
             </div>
-          </div></form>
+          </div>
+        </form>
         <footer className="settings-footer">
-          <button type="button" id="cancel-global-settings-btn" className="modal-btn modal-btn-secondary">Cancel</button>
-          <button type="button" id="save-global-settings-btn" className="modal-btn modal-btn-primary" disabled>Save Changes</button>
+          <button
+            type="button"
+            id="cancel-global-settings-btn"
+            className="modal-btn modal-btn-secondary"
+            onClick={() => navigate('/settings')}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            id="save-global-settings-btn"
+            className="modal-btn modal-btn-primary"
+            onClick={() => console.log('Save Global Settings')}
+          >
+            Save Changes
+          </button>
         </footer>
       </div>
     </div>

--- a/src/pages/Hub.tsx
+++ b/src/pages/Hub.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 export default function Hub() {
   const navigate = useNavigate();
+  const [dropdownOpen, setDropdownOpen] = useState(false);
   useEffect(() => {
     console.log('Route loaded: /hub');
   }, []);
@@ -28,14 +29,19 @@ export default function Hub() {
             <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><circle cx={12} cy={12} r={3} /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" /></svg>
           </button>
           <div className="user-profile-menu">
-            <button className="user-profile-trigger" aria-haspopup="true" aria-expanded="false">
+            <button
+              className="user-profile-trigger"
+              aria-haspopup="true"
+              aria-expanded={dropdownOpen}
+              onClick={() => setDropdownOpen((prev) => !prev)}
+            >
               <div className="user-avatar">
                 <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" /><circle cx={12} cy={7} r={4} /></svg>
               </div>
               <span className="user-name">Alex Thorne</span>
               <svg className="chevron-down" xmlns="http://www.w3.org/2000/svg" width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><polyline points="6 9 12 15 18 9" /></svg>
             </button>
-            <div className="user-profile-dropdown hidden">
+            <div className={`user-profile-dropdown ${dropdownOpen ? '' : 'hidden'}`}>
               <div className="dropdown-user-info">
                 <strong>Alex Thorne</strong>
                 <span>alex.thorne@example.com</span>


### PR DESCRIPTION
## Summary
- enable profile dropdown and logout in hub page
- add placeholder add container button
- wire global settings tabs, cancel, and save stubs

## Testing
- `npx tsc --noEmit`
- `npx playwright test` *(fails: browserType.launch executable missing; playwright install ERR_SOCKET_CLOSED)*

------
https://chatgpt.com/codex/tasks/task_e_68a23a46443483279369209d208fe107